### PR TITLE
#17 Pipeline Scheduler Terraform

### DIFF
--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -1,0 +1,75 @@
+# Define iam role
+resource "aws_iam_role" "c14-bandcamp-pipeline-lambda-role" {
+  name = "c14-bandcamp-pipeline-lambda-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "sts:AssumeRole"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+# Define lambda function
+resource "aws_lambda_function" "c14-bandcamp-pipeline-lambda-function" {
+  function_name = "c14-band-camp-pipeline-lambda"
+  role          = aws_iam_role.c14-bandcamp-pipeline-lambda-role.arn
+  package_type  = "Image"
+  image_uri     = "INSERT ECR IMAGE URI HERE"
+  timeout       = 900 
+  memory_size   = 512
+  environment {
+    variables = {
+      DB_USER            = var.db_user
+      DB_PASSWORD        = var.db_password
+    }
+  }
+}
+
+# Create cloudwatch event rule - schedule for the event
+resource "aws_cloudwatch_event_rule" "c14-bandcamp-pipeline-rule" {
+  name                = "c14-bandcamp-pipeline-rule"
+  description         = "trigger the pipeline lambda every three minutes"
+  schedule_expression = "cron(0/3 * * * ? *)"
+}
+
+# Eventbridge target for lambda
+resource "aws_cloudwatch_event_target" "c14-bandcamp-pipeline-target" {
+  rule      = aws_cloudwatch_event_rule.c14-bandcamp-pipeline-rule.name
+  arn       = aws_lambda_function.c14-bandcamp-pipeline-lambda-function.arn
+}
+
+# Lambda permission - allows eventbridge to trigger lambda
+resource "aws_lambda_permission" "c14-bandcamp-pipeline-lambda-permission" {
+  statement_id  = "AllowEventBridgeInvokeETL"
+  action        = "lambda:InvokeFunction"
+  principal     = "events.amazonaws.com"
+  function_name = aws_lambda_function.c14-bandcamp-pipeline-lambda-function.function_name
+  source_arn    = aws_cloudwatch_event_rule.c14-bandcamp-pipeline-rule.arn
+}
+
+# Policy to define permissions
+resource "aws_iam_policy" "c14-bandcamp-pipeline-policy" {
+  name        = "c14-bandcamp-pipeline-policy"
+  policy      = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:PutObject", "s3:GetObject", "ecs:RunTask"]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# Attach policy to iam role
+resource "aws_iam_role_policy_attachment" "c14-bandcamp-pipeline-policy-attachment" {
+  role       = aws_iam_role.c14-bandcamp-pipeline-lambda-role.name
+  policy_arn = aws_iam_policy.c14-bandcamp-pipeline-policy.arn
+}

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -1,4 +1,4 @@
-resource "aws_db_instance" "band-camp-tracker-db" {
+resource "aws_db_instance" "c14-bandcamp-db" {
   allocated_storage                     = "20"
   auto_minor_version_upgrade            = "true"
   availability_zone                     = "eu-west-2c"
@@ -15,7 +15,7 @@ resource "aws_db_instance" "band-camp-tracker-db" {
   engine_lifecycle_support              = "open-source-rds-extended-support-disabled"
   engine_version                        = "16.3"
   iam_database_authentication_enabled   = "false"
-  identifier                            = "band-camp-tracker-db"
+  identifier                            = "c14-bandcamp-db"
   instance_class                        = "db.t3.micro"
   iops                                  = "0"
   license_model                         = "postgresql-license"

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -1,3 +1,28 @@
+# Security group to allow traffic on the postresql 5432 port
+resource "aws_security_group" "c14-bandcamp-sg" {
+  description = "Allow access to PostgreSQL from anywhere"
+
+  egress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = "0"
+    protocol    = "-1"
+    self        = "false"
+    to_port     = "0"
+  }
+
+  ingress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = "5432"
+    protocol    = "tcp"
+    self        = "false"
+    to_port     = "5432"
+  }
+
+  name   = "c14-bandcamp-sg"
+  vpc_id = "vpc-0344763624ac09cb6"
+}
+
+# The RDS database instance 
 resource "aws_db_instance" "c14-bandcamp-db" {
   allocated_storage                     = "20"
   auto_minor_version_upgrade            = "true"
@@ -8,6 +33,7 @@ resource "aws_db_instance" "c14-bandcamp-db" {
   ca_cert_identifier                    = "rds-ca-rsa2048-g1"
   copy_tags_to_snapshot                 = "false"
   customer_owned_ip_enabled             = "false"
+  db_name                               = "c14_bandcamp_db"
   db_subnet_group_name                  = "c14-public-subnet-group"
   dedicated_log_volume                  = "false"
   deletion_protection                   = "false"
@@ -35,7 +61,7 @@ resource "aws_db_instance" "c14-bandcamp-db" {
   storage_encrypted                     = "true"
   storage_throughput                    = "0"
   storage_type                          = "gp2"
-  vpc_security_group_ids                = [var.db_sec_group_id]
+  vpc_security_group_ids                = [aws_security_group.c14-bandcamp-sg.id]
   username                              = var.db_user
   password                              = var.db_password
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -9,9 +9,3 @@ variable "db_password" {
   type        = string
   sensitive   = true
 }
-
-variable "db_sec_group_id" {
-  description = "security group id for the S3 database"
-  type        = string
-  sensitive   = true
-}


### PR DESCRIPTION
- Created the pipeline event scheduler terraform to run the pipeline on a Lambda instance every three minutes
- For now we have a placeholder value for the ECR URI. The ECR will need to be created, and the pipeline docker image uploaded before we can replace it with the real value
- I have also made some small changes to the names of the RDS database terraform resources to match the agreed naming convention