### PR TITLE
Adding terraform for the ECS for the pipeline

### DIFF
--- a/terraform/pipeline.tf
+++ b/terraform/pipeline.tf
@@ -73,3 +73,38 @@ resource "aws_iam_role_policy_attachment" "c14-bandcamp-pipeline-policy-attachme
   role       = aws_iam_role.c14-bandcamp-pipeline-lambda-role.name
   policy_arn = aws_iam_policy.c14-bandcamp-pipeline-policy.arn
 }
+
+
+# ECR to store the pipeline docker image
+resource "aws_ecr_repository" "c14-bandcamp-pipeline-ecr" {
+  name                 = "c14-bandcamp-pipeline-ecr"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+# ECR policy to only keep the most recent image upload
+resource "aws_ecr_lifecycle_policy" "c14-bandcamp-pipeline-ecr-lifecycle-policy" {
+  repository = aws_ecr_repository.c14-bandcamp-pipeline-ecr.name
+
+  policy = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Keep only the most recently upload 3 images",
+            "selection": {
+                "tagStatus": "any",
+                "countType": "imageCountMoreThan",
+                "countNumber": 3
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
+}


### PR DESCRIPTION
Added the terraform code for the ECS to our pipeline.tf file. 

Added a rule for it so that only the most recent image upload is maintained. This removes the need to manually delete the old one if we upload a new image. It's also worth noting that this means if we upload a new docker image it will break the pipeline until connected, as the existing image will be deleted (with the URI that is currently connected to the Lambda)