### PR TITLE
added graphs to dashboard and fixed filter for sales over time

### DIFF
--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -11,6 +11,7 @@ import streamlit as st
 import boto3
 from dotenv import load_dotenv
 from subscribe_page_commands import (
+    get_connection,
     get_genres_from_db,
     check_if_email_exists,
     add_subscriber_info_to_db,
@@ -19,6 +20,11 @@ from subscribe_page_commands import (
     get_existing_subscriber_preferences,
     update_existing_subscriber_info
 )
+from streamlit_graphs.release_type_chart import visualize_release_types
+from streamlit_graphs.sales_by_country import visualize_country_sales
+from streamlit_graphs.sales_over_time import visualize_sales_per_hour
+from streamlit_graphs.top_artist_sales import visualize_sales_per_artist_over_time
+from streamlit_graphs.top_genre_sales import visualize_genre_sales
 
 
 def is_valid_email(email: str) -> bool:
@@ -33,11 +39,20 @@ def main_overview() -> None:
     st.write("https://bandcamp.com/")
     st.write("Welcome to the Main Overview Page.")
 
+    conn = get_connection()
+    visualize_release_types(conn)
+    visualize_sales_per_hour(conn)
+
 
 def trends_page() -> None:
     """Creates trends page on dashboard."""
     st.title("Trends Page")
     st.write("Explore trends on this page.")
+
+    conn = get_connection()
+    visualize_sales_per_artist_over_time(conn)
+    visualize_genre_sales(conn)
+    visualize_country_sales(conn)
 
 
 def download_reports_from_s3(s3: boto3.client, bucket_name: str, subfolder: str) -> list[str]:

--- a/dashboard/streamlit_graphs/release_type_chart.py
+++ b/dashboard/streamlit_graphs/release_type_chart.py
@@ -51,7 +51,7 @@ def get_release_type_count(connection: extensions.connection) -> pd.DataFrame:
     return pd.read_sql_query(query, connection)
 
 
-def create_release_type_pie_chart(connection):
+def create_release_type_pie_chart(connection: psycopg2.connect) -> alt.Chart:
     """
     Creates and returns a pie chart showing the count of 
     each release type (Albums and Tracks).

--- a/dashboard/streamlit_graphs/sales_over_time.py
+++ b/dashboard/streamlit_graphs/sales_over_time.py
@@ -73,7 +73,7 @@ def fetch_sales_within_date_range(connection: psycopg2.connect, start_date: date
 
 
 def plot_sales_per_hour(connection: psycopg2.connect,
-                        start_date: date, end_date=None) -> alt.Chart | None:
+                        start_date: date, end_date: date = None) -> alt.Chart | None:
     """
     Plots a line graph of sales per hour for the current day.
     """
@@ -81,11 +81,11 @@ def plot_sales_per_hour(connection: psycopg2.connect,
         sales_data = fetch_sales_within_date_range(
             connection, start_date, end_date)
         if sales_data.empty:
-            st.error("EMPTY - No data available to display")
+            st.error("No data available to display")
             return None
 
     except AttributeError as e:
-        st.error("AE - No data available to display")
+        st.error("No data available to display")
 
     if not end_date:
         chart_title = f"Sales on {str(start_date)}"
@@ -125,12 +125,12 @@ def visualize_sales_per_hour(connection: psycopg2.connect) -> None:
     Visualizes sales per hour within a date range for the Streamlit dashboard.
     """
     default_end = datetime.now()
-    default_start = date(2024, 12, 5)
+    default_start = date(2024, 12, 5)  # the first day of data collection
 
     date_range = st.date_input(
         "Select a date range:",
         value=(default_start, default_end),  # Default range
-        min_value=date(2024, 12, 5),  # Earliest selectable date
+        min_value=default_start,  # Earliest selectable date
         max_value=date.today()       # Latest selectable date
     )
 

--- a/dashboard/streamlit_graphs/sales_over_time.py
+++ b/dashboard/streamlit_graphs/sales_over_time.py
@@ -33,7 +33,7 @@ def get_connection() -> extensions.connection | None:
         return None
 
 
-def fetch_sales_within_date_range(connection, start_date, end_date) -> pd.DataFrame | None:
+def fetch_sales_within_date_range(connection: psycopg2.connect, start_date: date, end_date: date) -> pd.DataFrame | None:
     """
     Fetches sales data aggregated by hour for a given date range.
     """
@@ -72,8 +72,8 @@ def fetch_sales_within_date_range(connection, start_date, end_date) -> pd.DataFr
         return None
 
 
-def plot_sales_per_hour(connection: extensions.connection,
-                        start_date: datetime, end_date=None) -> alt.Chart | None:
+def plot_sales_per_hour(connection: psycopg2.connect,
+                        start_date: date, end_date=None) -> alt.Chart | None:
     """
     Plots a line graph of sales per hour for the current day.
     """
@@ -120,7 +120,7 @@ def plot_sales_per_hour(connection: extensions.connection,
     return chart
 
 
-def visualize_sales_per_hour(connection: extensions.connection) -> None:
+def visualize_sales_per_hour(connection: psycopg2.connect) -> None:
     """
     Visualizes sales per hour within a date range for the Streamlit dashboard.
     """


### PR DESCRIPTION
Added the graphs and charts to the dashboard, and fixed the filter on 'Sales over time' to allow for a single day to be selected, and be inclusive of the end date of a selected date range. Referring to #114 .